### PR TITLE
chore(issues): adopt GitHub Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,40 @@
+name: "Bug"
+description: Something is broken or incorrect.
+title: "fix(scope): short description"
+labels: ["type:bug", "priority:P1"]
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: What happened?
+      description: Include logs/CLI output.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      placeholder: Exact commands from a clean repo.
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["S1-blocker", "S2-major", "S3-minor"]
+      default: 1
+    validations:
+      required: true
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - label: Affects live run
+        - label: Data/cost risk

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,20 @@
+name: "Chore / Task"
+description: Housekeeping, refactors, CI, docs—no user-visible change.
+title: "chore(scope): short description"
+labels: ["type:chore", "priority:P2"]
+body:
+  - type: textarea
+    id: task
+    attributes:
+      label: Task
+      description: What will be done?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: |
+        - CI green
+        - README adjusted (if needed)
+        - No behavior changes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / help
+    url: https://github.com/thenarfer/cloud-starter/discussions
+    about: Ask questions and share ideas here.

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,81 @@
+name: "Story / Feature"
+description: Plan a user-visible change with clear AC and demo steps.
+title: "feat(scope): short description"
+labels: ["type:story"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One short paragraph describing the desired outcome.
+      placeholder: As a developer, I want ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why (problem / context)
+      description: Why are we doing this? Link prior issues if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ac
+    attributes:
+      label: Acceptance Criteria (PO-owned)
+      description: Bullet list. Be specific and verifiable.
+      placeholder: |
+        - Shows X, Y in CLI table
+        - JSON includes fields A, B
+        - Non-happy paths handled with clear error
+    validations:
+      required: true
+
+  - type: textarea
+    id: demo
+    attributes:
+      label: Demo (commands & expected output)
+      description: Copy/paste commands used in Sprint Review.
+      placeholder: |
+        spin up --count 1 --apply --table
+        spin status --table
+        spin down --group <id> --apply --table
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: dor
+    attributes:
+      label: Definition of Ready (quick check)
+      options:
+        - label: Scope is clear and testable
+        - label: Risks/unknowns called out
+        - label: AC verifiable via CLI commands
+        - label: Labels set (type/priority/size/area)
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: ["priority:P0", "priority:P1", "priority:P2"]
+      default: 1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      options: ["size:XS", "size:S", "size:M", "size:L", "size:XL"]
+      default: 2
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Area/scope label (optional)
+      placeholder: area:status
+    validations:
+      required: false

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add issues to project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/thenarfer/projects/1
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # If you have a “Status” field in the project:
+          fields: |
+            Status=Backlog


### PR DESCRIPTION
## Why
Keep every new issue consistent and verifiable (AC, Demo, DoR) with fewer back-and-forths. YAML Issue Forms enforce structure and can apply labels automatically.

## What changed
- Added **Issue Forms**:
  - `.github/ISSUE_TEMPLATE/story.yml`
  - `.github/ISSUE_TEMPLATE/bug.yml`
  - `.github/ISSUE_TEMPLATE/chore.yml`
- Added `config.yml` to disable blank issues and guide people to the forms.
- Added workflow to auto-add new issues to the Project backlog.

## How to test
1. Go to **New issue** → verify you see **Story / Bug / Chore** cards (no “blank issue”).
2. Submit a test issue and confirm:
   - Required fields are enforced.
   - Default labels are applied (for any label names that already exist).
   - The issue appears in the Project’s Backlog/Status.

## Safety
- Only .github/config and workflow files; no runtime code changed.

## Links
- Closes #28