### PR TITLE
chore(process): Sprint Plan → Milestone system (Issue Form + /sync-sprint)

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint-plan.yml
+++ b/.github/ISSUE_TEMPLATE/sprint-plan.yml
@@ -1,0 +1,115 @@
+name: "Sprint Plan"
+description: "Create a structured sprint plan (this Issue will be the source of truth)"
+title: "Sprint <N> — <Short name> (<YYYY-MM-DD> → <YYYY-MM-DD>)"
+labels: ["sprint-plan"]
+body:
+  - type: input
+    id: milestone_name
+    attributes:
+      label: Milestone name (exact)
+      description: "Example: Sprint 5 — Hardening & UX (2025-09-15 → 2025-09-16)"
+      placeholder: "Sprint <N> — <Short name> (<YYYY-MM-DD> → <YYYY-MM-DD>)"
+    validations:
+      required: true
+
+  - type: input
+    id: start_date
+    attributes:
+      label: Start date (YYYY-MM-DD)
+      placeholder: "2025-09-15"
+    validations:
+      required: true
+
+  - type: input
+    id: end_date
+    attributes:
+      label: End date (YYYY-MM-DD)
+      placeholder: "2025-09-16"
+    validations:
+      required: true
+
+  - type: textarea
+    id: sprint_goal
+    attributes:
+      label: Sprint Goal
+      description: "One concise, outcome-oriented paragraph."
+      placeholder: "Harden the live path and improve UX for spin..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope_committed
+    attributes:
+      label: Scope (Committed P0s)
+      description: "Bullet list. Reference issues with #id if they already exist."
+      placeholder: |
+        - #123 feat(up): resolve AL2023 AMI via SSM (S)
+          Acceptance:
+            - AMI resolved from SSM Parameter Store...
+        - #124 feat(up): bounded waiter + --table (S)
+          Acceptance:
+            - Wait until running or timeout (~90s)...
+    validations:
+      required: true
+
+  - type: textarea
+    id: stretch
+    attributes:
+      label: Stretch (P1s, optional)
+      placeholder: |
+        - #125 feat(status): health + uptime + --table (S)
+        - #126 feat(down): waiter + summary (XS)
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Out of Scope (Non-goals)
+      placeholder: |
+        - Multi-cloud
+        - IAM hardening
+        - Autoscaling
+
+  - type: textarea
+    id: demo_script
+    attributes:
+      label: Demo Script (what we will show)
+      render: shell
+      placeholder: |
+        python -m venv .venv && source .venv/bin/activate
+        pip install -e .[test]
+        export SPIN_OWNER=@yourhandle
+        spin up --count 1 --table
+        spin status --table
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks & Mitigations
+      placeholder: |
+        - Waiter flakiness (M) → bounded timeouts; clear guidance
+        - SSM drift (M) → explicit parameter name & tests
+
+  - type: textarea
+    id: ways_of_working
+    attributes:
+      label: Ways of Working
+      placeholder: |
+        - One issue → one PR; squash merge
+        - Use PR templates; include “Closes #<id>”
+
+  - type: textarea
+    id: done_when
+    attributes:
+      label: Done when (Definition of Done for this sprint)
+      placeholder: |
+        - All P0s merged via PR; CI green
+        - Demo script runs end-to-end
+        - Board tidy (milestone complete or only carries stretch)
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmations
+      options:
+        - label: "I understand we’ll sync this Issue into the milestone description via /sync-sprint."
+          required: true

--- a/.github/workflows/sprint-digest.yml
+++ b/.github/workflows/sprint-digest.yml
@@ -1,0 +1,60 @@
+name: sprint-digest
+
+on:
+  schedule:
+    - cron: "0 06 * * 1-5"  # 06:00 UTC ≈ 08:00 Oslo most of the year
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post digest to sprint plan issue(s)
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          result-encoding: string
+          script: |
+            // Find open milestones that were synced by this workflow
+            const { data: milestones } = await github.rest.issues.listMilestones({ ...context.repo, state: 'open' });
+            const targets = milestones.filter(m => (m.description||'').includes('<!-- sprint-plan-issue:'));
+
+            for (const m of targets) {
+              const issueNum = Number((m.description.match(/<!-- sprint-plan-issue:(\d+) -->/)||[])[1]);
+              if (!issueNum) continue;
+
+              // Gather issue stats in this milestone
+              const perPage = 100;
+              let page = 1, openCount = 0, closedCount = 0, lines = [];
+              while (true) {
+                const { data: issues } = await github.rest.issues.listForRepo({
+                  ...context.repo,
+                  milestone: m.number,
+                  state: 'all',
+                  per_page: perPage,
+                  page
+                });
+                if (!issues.length) break;
+                for (const is of issues) {
+                  if (is.pull_request) continue; // issues only
+                  if (is.state === 'open') openCount++; else closedCount++;
+                }
+                page++;
+              }
+
+              const total = openCount + closedCount;
+              const pct = total ? Math.round((closedCount / total) * 100) : 0;
+
+              const body = [
+                `**Daily Sprint Digest – ${m.title}**`,
+                `- Window: ${m.due_on ? '(ends ' + m.due_on.substring(0,10) + ')' : ''}`,
+                `- Issues: ${closedCount}/${total} closed (${pct}%)`,
+                ``,
+                `_Milestone_: ${m.title}`
+              ].join('\n');
+
+              await github.rest.issues.createComment({ ...context.repo, issue_number: issueNum, body });
+            }

--- a/.github/workflows/sprint-normalizer.yml
+++ b/.github/workflows/sprint-normalizer.yml
@@ -1,0 +1,35 @@
+name: sprint-normalizer (warn-only)
+
+on:
+  schedule:
+    - cron: "30 06 * * 1-5"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  warn:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect drifts and warn
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { data: milestones } = await github.rest.issues.listMilestones({ ...context.repo, state: 'open' });
+            for (const m of milestones) {
+              const match = (m.description||'').match(/<!-- sprint-plan-issue:(\d+) -->/);
+              if (!match) continue;
+              const issue_number = Number(match[1]);
+
+              // If description doesn't contain our standard sections, post a gentle warning.
+              const required = ['## Sprint Goal', '## Scope (Committed P0s)'];
+              const missing = required.filter(h => !m.description.includes(h));
+              if (missing.length) {
+                await github.rest.issues.createComment({
+                  ...context.repo, issue_number,
+                  body: `⚠️ Heads up: the milestone **${m.title}** description no longer matches the standard sections (${missing.join(', ')}). Consider running \`/sync-sprint\` again.`
+                });
+              }
+            }

--- a/.github/workflows/sprint-sync.yml
+++ b/.github/workflows/sprint-sync.yml
@@ -1,0 +1,147 @@
+name: sprint-sync
+
+on:
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: sprint-sync-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  handle:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue && contains(github.event.issue.labels.*.name, 'sprint-plan')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on command
+        id: gate
+        env:
+          BODY: ${{ github.event.comment.body }}
+          EVT:  ${{ github.event_name }}
+        run: |
+          if [ "$EVT" = "workflow_dispatch" ]; then
+            echo "cmd=/sync-sprint" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          b="$(echo "$BODY" | tr '[:upper:]' '[:lower:]')"
+          case "$b" in
+            */help-sprint*)   echo "cmd=/help-sprint"   >> "$GITHUB_OUTPUT" ;;
+            */preview-sprint*) echo "cmd=/preview-sprint" >> "$GITHUB_OUTPUT" ;;
+            */sync-sprint*)    echo "cmd=/sync-sprint"    >> "$GITHUB_OUTPUT" ;;
+            *) echo "No sprint command found"; exit 78 ;; # neutral
+          esac
+
+      - name: Process command
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const cmd = core.getInput('cmd', { required: false }) || '${{ steps.gate.outputs.cmd }}';
+            const issue_number = (context.payload.issue && context.payload.issue.number) || core.getInput('issue_number') || context.issue.number;
+            const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number });
+
+            if (!issue.labels.map(l => l.name).includes('sprint-plan')) {
+              core.info('Issue is not labeled sprint-plan; exiting neutral.');
+              return;
+            }
+
+            // Parse Issue form values by headings/labels we defined in the form
+            function pick(id, fallback='') {
+              // Issue forms include a leading "### <Label>\n\n<value>" blocks
+              const rx = new RegExp(`(?<=###\\s*${id.replace(/[.*+?^${}()|[\\]\\\\]/g,'\\\\$&')}\\s*\\n\\n)([\\s\\S]*?)(?=\\n\\n###|$)`, 'i');
+              const m = issue.body.match(rx);
+              return (m ? m[1].trim() : fallback).trim();
+            }
+
+            const milestoneName = pick('Milestone name (exact)');
+            const startDate = pick('Start date (YYYY-MM-DD)');
+            const endDate   = pick('End date (YYYY-MM-DD)');
+            const goal      = pick('Sprint Goal');
+            const scope     = pick('Scope \\(Committed P0s\\)');
+            const stretch   = pick('Stretch \\(P1s, optional\\)');
+            const nonGoals  = pick('Out of Scope \\(Non-goals\\)');
+            const demo      = pick('Demo Script \\(what we will show\\)');
+            const risks     = pick('Risks & Mitigations');
+            const wow       = pick('Ways of Working');
+            const doneWhen  = pick('Done when \\(Definition of Done for this sprint\\)');
+
+            if (!milestoneName || !startDate || !endDate || !goal || !scope) {
+              const msg = `Missing required fields. Need: Milestone name, dates, Sprint Goal, Scope.`;
+              if (cmd === '/sync-sprint') {
+                await github.rest.issues.createComment({ ...context.repo, issue_number, body: `⚠️ ${msg}` });
+              }
+              core.setFailed(msg);
+              return;
+            }
+
+            const header = `# ${milestoneName}\n\n**Window:** ${startDate} → ${endDate}\n\n**Source plan:** #${issue.number}\n<!-- sprint-plan-issue:${issue.number} -->`;
+            const sections = [
+              ['## Sprint Goal', goal],
+              ['## Scope (Committed P0s)', scope],
+              ...(stretch ? [['## Stretch', stretch]] : []),
+              ...(nonGoals ? [['## Out of Scope (Non-goals)', nonGoals]] : []),
+              ...(demo ? [['## Demo Script', '```bash\n' + demo.replace(/^```(bash)?/,'').replace(/```$/,'').trim() + '\n```']] : []),
+              ...(risks ? [['## Risks & Mitigations', risks]] : []),
+              ...(wow ? [['## Ways of Working', wow]] : []),
+              ...(doneWhen ? [['## Done when', doneWhen]] : []),
+            ];
+            const rendered = [header, ...sections.map(([h, b]) => `${h}\n\n${b}`)].join('\n\n');
+
+            if (cmd === '/help-sprint') {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number,
+                body: [
+                  '**Sprint commands**',
+                  '- `/preview-sprint` – render a preview of the milestone description',
+                  '- `/sync-sprint` – create/update the milestone with this description',
+                  '',
+                  '_Milestone title & dates come from the form fields; this Issue remains the source of truth._'
+                ].join('\n')
+              });
+              return;
+            }
+
+            if (cmd === '/preview-sprint') {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number,
+                body: `<details><summary>Milestone preview for <strong>${milestoneName}</strong></summary>\n\n${rendered}\n\n</details>`
+              });
+              return;
+            }
+
+            // /sync-sprint
+            // Find or create milestone by exact title
+            const { data: milestones } = await github.rest.issues.listMilestones({
+              ...context.repo, state: 'open'
+            });
+            let milestone = milestones.find(m => m.title === milestoneName);
+            const dueOn = new Date(endDate + 'T23:59:59Z').toISOString();
+
+            if (!milestone) {
+              const created = await github.rest.issues.createMilestone({
+                ...context.repo,
+                title: milestoneName,
+                description: rendered,
+                due_on: dueOn
+              });
+              milestone = created.data;
+            } else {
+              await github.rest.issues.updateMilestone({
+                ...context.repo,
+                milestone_number: milestone.number,
+                title: milestoneName,
+                description: rendered,
+                due_on: dueOn,
+                state: 'open'
+              });
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo, issue_number,
+              body: `✅ Synced to milestone **${milestone.title}** (due ${endDate}).`
+            });

--- a/README.md
+++ b/README.md
@@ -3,59 +3,8 @@
 A transparent learning project to practice Product Ownership and disciplined delivery.  
 **Product Goal:** Enable developers to self-serve a few on-demand servers for tests within minutes.
 
----
-
-## Sprint 3 — Hardened Live Path & UX
-
-**Sprint Goal:** Harden the **live path** and improve **UX** for `spin`:  
-- Resolve latest AL2023 AMI via SSM  
-- Add bounded waiters for instance readiness  
-- Add human-friendly `--table` output for `up | status | down`  
-- Enrich `status` with **health** and **uptime**  
-- Add bounded waiter + summary for `down`
-
-### Scope (Committed P0s)
-
-- **`feat(up)`: resolve AL2023 AMI via SSM**  
-  - AMI resolved from SSM Parameter Store (`/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64`).  
-  - Fail fast with clear, actionable error if missing/unsupported.  
-  - Tested via moto + unit tests.
-
-- **`feat(up)`: bounded waiter + `--table` output**  
-  - After `up --apply`, wait until instances are **running** or **timeout (~90s)**.  
-  - Exit code non-zero on timeout with guidance.  
-  - Default output = JSON; with `--table`, print:  
-    ```
-    InstanceId | PublicIp | State | SpinGroup
-    ```
-
-- **`feat(status)`: health + uptime + `--table`**  
-  - `status` enriches with `health` (`OK | IMPAIRED | INITIALIZING | UNKNOWN`) and `uptime_min` (minutes since LaunchTime).  
-  - JSON remains default; `--table` prints:  
-    ```
-    InstanceId | State | Health | Uptime(min) | SpinGroup
-    ```
-
-- **`feat(down)`: table output**  
-  - Default JSON unchanged.  
-  - With `--table`, print:  
-    ```
-    InstanceId | State
-    ```
-
-- **`feat(down)`: bounded waiter + friendly summary**  
-  - After `down --apply`, wait until instances are **terminated** or **timeout (~90s)**.  
-  - Exit code non-zero on timeout with guidance.  
-  - JSON includes `"warning"` field if timeout.  
-  - Table output unchanged.
-
-### Non-goals (not in this sprint)
-
-- Multi-cloud (Azure/GCP), Terraform/IaC  
-- SSH/provisioners, IAM hardening  
-- Autoscaling, budgets/policies beyond basic teardown  
-- Monitoring/alerts  
-- Real instance lifecycle beyond the minimal demo  
+The `spin` CLI is functional and provides three basic commands: `up`, `status`, and `down`.  
+Dry-run is the default (safe), and live operations are explicitly guarded.
 
 ---
 
@@ -64,7 +13,7 @@ A transparent learning project to practice Product Ownership and disciplined del
 - Python **>= 3.11**
 - **Owner is required:** set `SPIN_OWNER` to your handle/email
 - Default region: **eu-north-1** (override with `SPIN_REGION` or `--region`)
-- For live calls (later): configure AWS credentials (`AWS_PROFILE` or `~/.aws`)
+- For live calls (optional): configure AWS credentials (`AWS_PROFILE` or `~/.aws`)
 
 ---
 
@@ -91,7 +40,7 @@ spin down --group demo --table
 
 **Notes**
 
-* With no `--apply` or without `SPIN_LIVE=1`, output is JSON previews and **no AWS calls** are made.
+* With no `--apply` or without `SPIN_LIVE=1`, output is JSON/table previews and **no AWS calls** are made.
 * `spin down` requires `--group` for destructive actions (override via `SPIN_ALLOW_GLOBAL_DOWN=1` only if you really mean it).
 
 ---
@@ -142,9 +91,49 @@ Tests cover dry-run behavior, waiter paths, table outputs, health/uptime enrichm
 
 ---
 
-## Roadmap (high level)
+## Sprints = Milestones (templated, low-friction)
 
-* **Sprint 3 (this sprint):** AMI resolution, waiter, enriched status, table UX, down waiter/summary
+We plan the sprint in a **Sprint Plan Issue** (Issue Form), then **sync** it to a **Milestone** description with a comment command. This keeps milestones consistent without blocking any work.
+
+### 1) Create the Sprint Plan (Issue Form)
+
+* New issue → **Sprint Plan**.
+* Fill the form:
+
+  * **Milestone name (exact)** → e.g. `Sprint 5 — Hardening & UX (2025-09-15 → 2025-09-16)`
+  * **Start/End dates (YYYY-MM-DD)**
+  * **Sprint Goal**, **Scope (Committed P0s)**, *(optional)* **Stretch**, **Non-goals**, **Demo Script**, **Risks & Mitigations**, **Ways of Working**, **Done when**
+
+> The Issue is the **source of truth**; it gets labeled `sprint-plan`.
+
+### 2) Preview & publish to Milestone
+
+Comment on the Sprint Plan Issue:
+
+* **`/preview-sprint`** → renders the milestone description as a comment (no changes).
+* **`/sync-sprint`** → creates/updates the milestone:
+
+  * **Title** = the **Milestone name (exact)** from the form
+  * **Due date** = Sprint **End date** (23:59:59Z)
+  * **Description** = templated sections + backlink to the Sprint Plan Issue
+
+Re-running `/sync-sprint` is safe and idempotent.
+
+### 3) Assign work as usual
+
+* Assign issues to the sprint milestone manually (unchanged).
+* Merging PRs **does not require** being in a sprint milestone.
+
+### Optional automations
+
+* **Daily digest**: weekday summary comment on the Sprint Plan Issue (closed/total %, days left).
+* **Normalizer (warn-only)**: gentle reminder if the milestone description drifts from the plan.
+
+---
+
+## Roadmap
+
+We track work via **GitHub Milestones (Sprints)** and the **Project board**. Upcoming work is planned in Sprint Plan issues and published to milestones as needed.
 
 ---
 


### PR DESCRIPTION
## Why now
Keep sprint milestones consistently structured with zero ceremony friction. We plan sprints in an Issue Form and publish the plan to the milestone via `/preview-sprint` and `/sync-sprint`. This reduces process drift, improves visibility, and aligns with DoD/DoR—without blocking merges.

## Scope
**Included**
- New Issue Form: `.github/ISSUE_TEMPLATE/sprint-plan.yml`
- New workflow: `.github/workflows/sprint-sync.yml` with slash commands:
  - `/help-sprint` – list commands
  - `/preview-sprint` – render milestone text as a comment (no write)
  - `/sync-sprint` – create/update milestone title, due date (EOD UTC), and description
- (Optional) `.github/workflows/sprint-digest.yml` (weekday progress comment)
- (Optional) `.github/workflows/sprint-normalizer.yml` (warn-only drift note)
- README: add “Sprints = Milestones (templated, low-friction)” user guide

**Out of scope / Non-goals**
- No merge gates; no blocking on sprint membership
- No auto-assignment of Issues/PRs to milestones
- No auto carry-over of spillover items

## Change
- Add Issue Form fields: Milestone name (exact), Start/End dates, Sprint Goal, Scope (Committed P0s), Stretch (optional), Non-goals, Demo Script, Risks & Mitigations, Ways of Working, Done when
- Add sprint-sync Action:
  - Minimal permissions: `issues:write`, `contents:read`
  - Uses `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd` (pinned SHA, v8)
  - Per-issue concurrency group; idempotent reruns
  - Hidden backlink marker in milestone description: `<!-- sprint-plan-issue:<id> -->`
- (Optional) Daily digest (cron ~06:00 UTC ≈ 08:00 Oslo) posts % done, days left
- (Optional) Normalizer (warn-only) comments if sections drift from template
- README updated; removed stale sprint section and documented the flow

## Validation
- [x] No user-visible product behavior change
- [x] User-visible impact: **none** (process/docs only)
- [x] CI green (no src/behavioral tests required)
- [x] Perf impact: none (GitHub Actions only)
- [x] Security/secrets: none; least-privilege permissions; actions pinned to SHAs
- [x] Docs updated in README

## Evidence (screens/logs/links)
- Create a **Sprint Plan** (Issue Form) → comment `/preview-sprint` → bot shows preview  
- Comment `/sync-sprint` → milestone is created/updated with title, due date, and description  
- Re-run `/sync-sprint` after editing the Issue → milestone updates (idempotent)  
- (If enabled) Digest posts a weekday summary on the Sprint Plan Issue

—  
_See `docs/DoR.md` & `docs/DoD.md`._  
**Closes #43 