### PR TITLE
This is a test/demo of Graphite.io (draft/closed)

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cloud-starter",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
---
name: "Spike / Research PR"
about: "TEST/DEMO - Timeboxed investigation results (merging docs/notes only)"
---

# THIS IS A TEST/DEMO OF GRAPHITE.IO

# spike(backend): Create simple Express server with mock activity feed

## Question / hypothesis
Can we quickly set up a minimal Express server to provide mock activity feed data for frontend development?

## Timebox
Planned: 2 hours | Actual: 1.5 hours

## Findings
- Express.js provides a straightforward way to create REST endpoints
- Mock data can be easily defined in-memory for development purposes
- The server setup is minimal and requires very little configuration

## Recommendation / Next steps
- Proceed with using Express for our backend API needs
- Expand the mock data structure as frontend requirements evolve
- Add proper error handling and validation in the next iteration
- Consider adding a database connection for persistent storage

## Outcome hygiene
- [ ] Decision captured in doc/ADR: <link>
- [ ] Follow-up Issues created and linked

## Evidence (notes, links, benchmarks)
- Created a basic Express server running on port 3000
- Implemented a `/feed` endpoint that returns mock activity data
- The server can be started with `node graphite-demo/server.js`
- Sample response includes structured activity items with id, title, and body

## Joke of the Day
Why do programmers prefer dark mode? Because light attracts bugs!
—
_See `docs/DoR.md` & `docs/DoD.md`._
**Closes #123**