### PR TITLE
fix(forms): correct issue template project schema (closes #56)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -39,5 +39,4 @@ body:
         - label: Affects live run
         - label: Data/cost risk
 projects:
-  - url: https://github.com/users/thenarfer/projects/1
-    workflow: .github/workflows/add-to-project.yml
+  - thenarfer/1

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -24,9 +24,6 @@ body:
         - Other
     validations:
       required: false
-projects:
-  - url: https://github.com/users/thenarfer/projects/1
-    workflow: .github/workflows/add-to-project.yml
 
   - type: textarea
     id: problem
@@ -105,3 +102,5 @@ projects:
           required: true
         - label: NFRs reviewed (or N/A)
           required: true
+projects:
+  - thenarfer/1

--- a/.github/ISSUE_TEMPLATE/sprint-plan.yml
+++ b/.github/ISSUE_TEMPLATE/sprint-plan.yml
@@ -19,9 +19,6 @@ body:
       placeholder: "2025-09-15"
     validations:
       required: true
-projects:
-  - url: https://github.com/users/thenarfer/projects/1
-    workflow: .github/workflows/add-to-project.yml
 
   - type: input
     id: end_date
@@ -116,3 +113,5 @@ projects:
       options:
         - label: "I understand we’ll sync this Issue into the milestone description via /sync-sprint."
           required: true
+projects:
+  - thenarfer/1

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -22,10 +22,7 @@ body:
         - Other
     validations:
       required: false
-projects:
-  - url: https://github.com/users/thenarfer/projects/1
-    workflow: .github/workflows/add-to-project.yml
-
+      
   - type: dropdown
     id: debt_type
     attributes:
@@ -77,3 +74,5 @@ projects:
           required: true
         - label: Scope small enough for a single PR (or clearly chunked)
           required: true
+projects:
+  - thenarfer/1


### PR DESCRIPTION
---

## name: "Tech Debt / Chore PR"

about: "Refactor, cleanups, dep bumps, infra chores"

## Why now

Risk reduction and maintainability by simplifying project references in issue templates.

## Scope

Updated project references in all issue templates (bug, feature, sprint-plan, tech-debt).

## Change

- Simplified project references from verbose URL format with workflow to shorthand `thenarfer/1` format
- Standardized project reference location in all templates
- Removed redundant workflow references

## Validation

- [ ] No user-visible behavior change
- [ ] User-visible impact: none
- [ ] CI green; tests updated if needed
- [ ] Perf impact considered (none)
- [ ] Security/secrets considered (none)
- [ ] Docs updated if user-visible

## Evidence (before/after, logs, links)

Before:

```
projects:
  - url: https://github.com/users/thenarfer/projects/1
    workflow: .github/workflows/add-to-project.yml
```

After:

```
projects:
  - thenarfer/1
```

—
_See_ _`docs/DoR.md`_ _&_ _`docs/DoD.md`._

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified project linking in all issue templates (Bug, Feature, Sprint Plan, Tech Debt) to use a direct repository project reference.
  * New issues created from templates will attach to the intended project consistently without per-template workflow config.
  * Minor template cleanup; no changes to the fields users complete when filing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->